### PR TITLE
ツイートでユーザーの名前が長い時にレイアウトが崩れるバグを修正

### DIFF
--- a/app/javascript/pages/replay/components/Tweet.vue
+++ b/app/javascript/pages/replay/components/Tweet.vue
@@ -2,7 +2,7 @@
   <div>
     <v-card class="pa-2">
       <div class="d-flex justify-space-between">
-        <div class="d-flex justify-start" style="width: 80%;">
+        <div class="d-flex justify-start width-80">
           <div class="d-inline-block">
             <img
               :src="profileImagePath"
@@ -12,23 +12,22 @@
               height="40px"
             >
           </div>
-          <div class="d-inline-block ml-2" style="width: 90%;">
+          <div class="d-inline-block ml-2 width-90">
             <div class="block">
               @{{ tweet.screen_name }}
             </div>
-            <div
-              class="block"
-              style="white-space: nowrap; text-overflow: ellipsis; overflow: hidden;"
-            >
+            <div class="block user-name">
               {{ tweet.name }}
             </div>
           </div>
         </div>
-        <img
-          src="../../../assets/Twitter_Logo_Blue.png"
-          width="35px"
-          height="35px"
-        >
+        <div>
+          <img
+            src="../../../assets/Twitter_Logo_Blue.png"
+            width="35px"
+            height="35px"
+          >
+        </div>
       </div>
       <p style="white-space: pre-line">
         {{ tweet.text }}
@@ -114,3 +113,16 @@ export default {
   }
 }
 </script>
+<style scoped>
+.user-name {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.width-80 {
+  width: 80%;
+}
+.width-90 {
+  width: 90%;
+}
+</style>

--- a/app/javascript/pages/replay/components/Tweet.vue
+++ b/app/javascript/pages/replay/components/Tweet.vue
@@ -2,7 +2,7 @@
   <div>
     <v-card class="pa-2">
       <div class="d-flex justify-space-between">
-        <div>
+        <div class="d-flex justify-start" style="width: 80%;">
           <div class="d-inline-block">
             <img
               :src="profileImagePath"
@@ -12,25 +12,23 @@
               height="40px"
             >
           </div>
-          <div class="d-inline-block">
+          <div class="d-inline-block ml-2" style="width: 90%;">
             <div class="block">
               @{{ tweet.screen_name }}
             </div>
             <div
               class="block"
-              style="white-space: nowrap"
+              style="white-space: nowrap; text-overflow: ellipsis; overflow: hidden;"
             >
               {{ tweet.name }}
             </div>
           </div>
         </div>
-        <div>
-          <img
-            src="../../../assets/Twitter_Logo_Blue.png"
-            width="35px"
-            height="35px"
-          >
-        </div>
+        <img
+          src="../../../assets/Twitter_Logo_Blue.png"
+          width="35px"
+          height="35px"
+        >
       </div>
       <p style="white-space: pre-line">
         {{ tweet.text }}


### PR DESCRIPTION
## 概要
表題のとおりです。
ツイートでユーザーの名前が長い時にレイアウトが崩れるバグを修正しました。